### PR TITLE
Add Leaderboard And Results Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ pip install -r requirements.txt
 
 ## Setup the database
 
-1. `createdb f1`
-2. `echo "CREATE TABLE schema_migrations (version integer NOT NULL);" | psql f1`
-3. [optional] Install [autoenv](https://github.com/kennethreitz/autoenv) and `echo "DATABASE_URL=postgres://localhost:5432/f1" > .env`
+1. `brew services start postgresql`
+2. `createdb f1`
+3. `echo "CREATE TABLE schema_migrations (version integer NOT NULL);" | psql f1`
+4. [optional] Install [autoenv](https://github.com/kennethreitz/autoenv) and `echo "DATABASE_URL=postgres://localhost:5432/f1" > .env`
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ## Install
 
+Postgres is required. To install this on macOS:
+
+```
+brew install postgresql
+```
+
 Ideally set up a [virtual environment](https://docs.python.org/3/library/venv.html), and then run:
 
 ```
@@ -12,10 +18,9 @@ pip install -r requirements.txt
 
 ## Setup the database
 
-1. Install [PostgreSQL](https://www.postgresql.org)
-2. `createdb f1`
-3. `echo "CREATE TABLE schema_migrations (version integer NOT NULL);" | psql f1`
-4. [optional] Install [autoenv](https://github.com/kennethreitz/autoenv) and `echo "DATABASE_URL=postgres://localhost:5432/f1" > .env`
+1. `createdb f1`
+2. `echo "CREATE TABLE schema_migrations (version integer NOT NULL);" | psql f1`
+3. [optional] Install [autoenv](https://github.com/kennethreitz/autoenv) and `echo "DATABASE_URL=postgres://localhost:5432/f1" > .env`
 
 ## Run
 

--- a/db.py
+++ b/db.py
@@ -84,7 +84,13 @@ def race_result(year, race):
 
     """Retrieves the results for a given race."""
 
-    query = 'SELECT * FROM results WHERE year = %s AND round = %s'
+    query = """SELECT results.position AS position, drivers.name AS driver,
+                 teams.name AS team, results.points AS points
+                   FROM results, drivers, teams
+                     WHERE results.driver_id = drivers.id
+                       AND results.team_id = teams.id
+                       AND results.year = %s
+                       AND round = %s"""
 
     with conn().cursor() as cur:
 

--- a/db.py
+++ b/db.py
@@ -85,7 +85,7 @@ def race_result(year, race):
     """Retrieves the results for a given race."""
 
     query = 'SELECT * FROM results WHERE year = %s AND round = %s'
-    
+
     with conn().cursor() as cur:
 
         cur.execute(query, (year, race))

--- a/db.py
+++ b/db.py
@@ -43,7 +43,7 @@ def migrate(migrations_directory):
         c.commit()
         for migration in sorted(list(migrations - existing)):
             print(f'Running migration {migration}')
-            filename = '{migrations_directory}/{migration}.sql'
+            filename = f'{migrations_directory}/{migration}.sql'
             with c.cursor() as curs, open(filename) as sql_file:
                 sql = sql_file.read()
                 print(sql)

--- a/db.py
+++ b/db.py
@@ -78,3 +78,15 @@ def driver_positions(driver, year=None):
         curs.execute(*query)
         positions = curs.fetchall()
         return [p[0] for p in positions]
+
+
+def race_result(year, race):
+
+    """Retrieves the results for a given race."""
+
+    query = 'SELECT * FROM results WHERE year = %s AND round = %s'
+    
+    with conn().cursor() as cur:
+
+        cur.execute(query, (year, race))
+        return cur.fetchall()

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-GB" xml:lang="en-GB">
+<head>
+  <meta c="UTF-8"/>
+  <title>F1 League</title>
+  <link rel="stylesheet" href="/static/main.css">
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,26 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-GB" xml:lang="en-GB">
-<head>
-<meta c="UTF-8"/>
-<title>F1 League</title>
-<link rel="stylesheet" href="/static/main.css">
-</head>
-<body>
-	<header>
-		<h1>F1 Results</h1>
-	</header>
-	<section id="results">
-		{% for race in races %}
-			<div class="race">
-				<h2 class="race_title">Race {{ race[0][2] }}</h2>
-				{% for result in race %}
-					<div class="result">
-						<span>{{ result[3] }} - </span>
-						<span>{{ result[0].replace('_', ' ').title() }}</span>
-					</div>
-				{% endfor %}
-			</div>
-		{% endfor %}
-	</section>
-</body>
-</html>
+{% extends "base.html" %}
+
+{% block content %}
+<header>
+  <h1>Leaderboard</h1>
+</header>
+
+<table class="users">
+  <tr>
+    <th>User</th>
+    <th>Points</th>
+  </tr>
+
+  {% for user in users | sort(attribute='points', reverse=True) %}
+  <tr>
+    <td>{{ user.name }}</td>
+    <td>{{ user.points }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -9,12 +9,16 @@
   <tr>
     <th>Position</th>
     <th>Driver</th>
+    <th>Team</th>
+    <th>Points</th>
   </tr>
 
   {% for result in results | sort(attribute='position') %}
   <tr>
     <td>{{ result.position }}</td>
     <td>{{ result.driver }}</td>
+    <td>{{ result.team }}</td>
+    <td>{{ result.points }}</td>
   </tr>
   {% endfor %}
 </table>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header>
+  <h1>Results - Round {{ race }} in {{ year }}</h1>
+</header>
+
+<table class="users">
+  <tr>
+    <th>Position</th>
+    <th>Driver</th>
+  </tr>
+
+  {% for result in results | sort(attribute='position') %}
+  <tr>
+    <td>{{ result.position }}</td>
+    <td>{{ result.driver }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/views.py
+++ b/views.py
@@ -39,7 +39,7 @@ def get_users():
         {'name': 'Dummy One', 'id': 1, 'points': 40},
         {'name': 'Dummy Two', 'id': 2, 'points': 34},
         {'name': 'Dummy Three', 'id': 3, 'points': 63}
-    ];
+    ]
 
 
 # ----- Routes ----- #

--- a/views.py
+++ b/views.py
@@ -47,9 +47,22 @@ def get_users():
 @app.route('/')
 def index():
 
+    """The homepage displays the user leaderboard."""
+
     users = get_users()
 
     return render_template('index.html', users=users)
+
+
+@app.route('/result/<int:year>/<int:race>')
+def result(year, race):
+
+    """Displays the result for a given race."""
+
+    race_result = db.race_result(year, race)
+    template_data = {'result': race_result, 'year': year, 'race': race}
+
+    return render_template('result.html', **template_data)
 
 
 @app.route('/prices')

--- a/views.py
+++ b/views.py
@@ -30,16 +30,26 @@ def split_races(results):
     return races
 
 
+def get_users():
+
+    """Retrieves a list of users from the db."""
+
+    # Dummy data for now.
+    return [
+        {'name': 'Dummy One', 'id': 1, 'points': 40},
+        {'name': 'Dummy Two', 'id': 2, 'points': 34},
+        {'name': 'Dummy Three', 'id': 3, 'points': 63}
+    ];
+
+
 # ----- Routes ----- #
 
-@app.route('/2014')
+@app.route('/')
 def index():
 
-    query = 'SELECT * FROM results WHERE year > 2014'
-    results = db.fetchall(query)
-    races = split_races(results)
+    users = get_users()
 
-    return render_template('index.html', races=races)
+    return render_template('index.html', users=users)
 
 
 @app.route('/prices')


### PR DESCRIPTION
# What?

Adds a couple of new views:

- **Leaderboard**: This displays a list of users ordered by the number of points they have. It's now the homepage.
- **Results**: Displays a list of results for a given race, specified by year and round.

Also applies a couple of bug fixes.

# Huh?

- Tweaked the README instructions for installing and running `postgres`. This has to be done before installing the python deps, otherwise the `psycopg2` install freaks out.
- Fixed a missing string format character.
- Added a new method to `db.py` for pulling out the race results.
- Started using a base template that others can extend.
- Altered the functionality of `index.html`, it now shows the leaderboard.
- Added a `result.html` template.
- Added views for the leaderboard and race results. Currently the leaderboard view uses dummy user data as this does not exist in the db.